### PR TITLE
Request: Change settings::$password to settings:$clientSecret

### DIFF
--- a/PHP/AuthorizationHelperForGraph.php
+++ b/PHP/AuthorizationHelperForGraph.php
@@ -6,7 +6,7 @@ class AuthorizationHelperForAADGraphService
     // Post the token generated from the symettric key and other information to STS URL and construct the authentication header
     public static function getAuthenticationHeader($appTenantDomainName, $appPrincipalId, $password){
         // Password
-        $clientSecret = urlencode(settings::$password);
+        $clientSecret = urlencode(settings::$clientSecret);
         // Information about the resource we need access for which in this case is graph.
         $graphId = 'https://graph.windows.net';
         $protectedResourceHostName = 'graph.windows.net';

--- a/PHP/GraphServiceAccessHelper.php
+++ b/PHP/GraphServiceAccessHelper.php
@@ -240,7 +240,7 @@
         public static function AddRequiredHeadersAndSettings($ch)
         {
             //Generate the authentication header
-            $authHeader = AuthorizationHelperForAADGraphService::GetAuthenticationHeader(Settings::$appTenantDomainName, Settings::$appPrincipalId, Settings::$password);
+            $authHeader = AuthorizationHelperForAADGraphService::GetAuthenticationHeader(Settings::$appTenantDomainName, Settings::$appPrincipalId, Settings::$clientSecret);
             // Add authorization header, request/response format header( for json) and a header to request content for Update and delete operations.  
             curl_setopt($ch, CURLOPT_HTTPHEADER, array($authHeader,  'Accept:application/json;odata=minimalmetadata',
                                                         'Content-Type:application/json;odata=minimalmetadata', 'Prefer:return-content'));

--- a/PHP/Settings.php
+++ b/PHP/Settings.php
@@ -3,7 +3,7 @@
     {        
         public static $appTenantDomainName = 'GraphDir1.onmicrosoft.com';
         public static $appPrincipalId = 'd266d7cc-13c7-4e89-aaac-8c699cf6aff2';    
-        public static $password = '8K+0OX6pvUZtaGo4YdUogT9xiF15aqyx1HbSvEg8Sec=';
+        public static $clientSecret = '8K+0OX6pvUZtaGo4YdUogT9xiF15aqyx1HbSvEg8Sec=';
         public static $apiVersion = "api-version=2013-11-08";
     }
 ?>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All done!  Before moving on to the next step, you need to find the Client ID of 
 #### Configuring the PHP sample
 1. Start Webmatrix, and select Open from the main screen, and select Folder, and navigate to the PHP folder of this project.  
 2. Webmatrix will initialize the application 
-3. Open the Settings.php file.  update the $appTenantDomainName to be your tenant identifier (any verified domain owned by the tenant, e.g. Contoso.onMicrosoft.com, contoso.com etc.).  update $appPrincipalId to the the Client ID recorded from previous step in the Azure Managment portal.  Update $password with the key value configured in the previous step in the Azure Management Portal. Save changes.
+3. Open the Settings.php file.  update the $appTenantDomainName to be your tenant identifier (any verified domain owned by the tenant, e.g. Contoso.onMicrosoft.com, contoso.com etc.).  update $appPrincipalId to the the Client ID recorded from previous step in the Azure Managment portal.  Update $clientSecret with the key value configured in the previous step in the Azure Management Portal. Save changes.
 4. Select Run, and try accessing Users, Groups and trying the differential query features.
 
 ## About The Code


### PR DESCRIPTION
Awesome example, really easy to follow. However, I think at some point the code was updated to work with a clientId & clientSecret instead of utilizing username & password for auth, and some people who don't read (like me) might have spent an embarrassing amount of time debugging bad requests because of this oversight on their part :)

I'm proposing these changes to make this example (hopefully) a bit easier to understand.
