### PR TITLE
Add API Version from Settings in Authorization file

### DIFF
--- a/PHP/AuthorizationHelperForGraph.php
+++ b/PHP/AuthorizationHelperForGraph.php
@@ -21,7 +21,7 @@ class AuthorizationHelperForAADGraphService
         //Using curl to post the information to STS and get back the authentication response    
         $ch = curl_init();
         // set url 
-        $stsUrl = 'https://login.windows.net/'.$appTenantDomainName.'/oauth2/token?api-version=1.0';        
+        $stsUrl = 'https://login.windows.net/'.$appTenantDomainName.'/oauth2/token?'.Settings::$apiVersion;        
         curl_setopt($ch, CURLOPT_URL, $stsUrl); 
         // Get the response back as a string 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 


### PR DESCRIPTION
It took me a little time to figure out why my calls were being denied. Turns out the API is hardcoded to version 1.0 in the Authorization file. This should instead pull from the Settings file.
