### PR TITLE
Use https for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every Azure subscription has an associated Azure Active Directory tenant.  If yo
 
 From your shell or command line:
 
-`git clone git@github.com:Azure-Samples/active-directory-php-graphapi-web.git`
+`git clone https://github.com/Azure-Samples/active-directory-php-graphapi-web.git`
 
 ### Step 2:  Run the sample from WebMatrix
 


### PR DESCRIPTION
Use HTTPS for git clone so ssh keys aren't required
